### PR TITLE
Backport delete_undef_values.rb from current puppetlabs-stdlib

### DIFF
--- a/lib/puppet/parser/functions/delete_undef_values.rb
+++ b/lib/puppet/parser/functions/delete_undef_values.rb
@@ -1,33 +1,42 @@
+# frozen_string_literal: true
+
+#
+# delete_undef_values.rb
+#
 module Puppet::Parser::Functions
-  newfunction(:delete_undef_values, :type => :rvalue, :doc => <<-EOS
-Returns a copy of input hash or array with all undefs deleted.
+  newfunction(:delete_undef_values, type: :rvalue, doc: <<-DOC
+    @summary
+      Returns a copy of input hash or array with all undefs deleted.
 
-*Examples:*
+    @example Example usage
 
-    $hash = delete_undef_values({a=>'A', b=>'', c=>undef, d => false})
+      $hash = delete_undef_values({a=>'A', b=>'', c=>undef, d => false})
+      Would return: {a => 'A', b => '', d => false}
 
-Would return: {a => 'A', b => '', d => false}
+      While:
+      $array = delete_undef_values(['A','',undef,false])
+      Would return: ['A','',false]
 
-    $array = delete_undef_values(['A','',undef,false])
+    > *Note:*
+    Since Puppet 4.0.0 the equivalent can be performed with the built-in
+    [`filter`](https://puppet.com/docs/puppet/latest/function.html#filter) function:
+    $array.filter |$val| { $val =~ NotUndef }
+    $hash.filter |$key, $val| { $val =~ NotUndef }
 
-Would return: ['A','',false]
+    @return [Array] The given array now issing of undefined values.
+    DOC
+  ) do |args|
+    raise(Puppet::ParseError, "delete_undef_values(): Wrong number of arguments given (#{args.size})") if args.empty?
 
-      EOS
-    ) do |args|
-
-    raise(Puppet::ParseError,
-          "delete_undef_values(): Wrong number of arguments given " +
-          "(#{args.size})") if args.size < 1
-
-    unless args[0].is_a? Array or args[0].is_a? Hash
-      raise(Puppet::ParseError,
-            "delete_undef_values(): expected an array or hash, got #{args[0]} type  #{args[0].class} ")
+    unless args[0].is_a?(Array) || args[0].is_a?(Hash)
+      raise(Puppet::ParseError, "delete_undef_values(): expected an array or hash, got #{args[0]} type  #{args[0].class} ")
     end
     result = args[0].dup
     if result.is_a?(Hash)
-      result.delete_if {|key, val| val.equal? :undef}
+      result.delete_if { |_, val| val.equal?(:undef) || val.nil? }
     elsif result.is_a?(Array)
       result.delete :undef
+      result.delete nil
     end
     result
   end


### PR DESCRIPTION
This backports delete_undef_values.rb from upstream (https://raw.githubusercontent.com/puppetlabs/puppetlabs-stdlib/main/lib/puppet/parser/functions/delete_undef_values.rb).

This is necessary for Puppet 6 hosts, or Puppet 4 clients running against Puppet 6 servers; it seems that undef was being treated by Ruby as nil, and therefore it wasn't being truncated. This meant that for example in Duplicity, where we pass an undef signing key, it got treated as an empty string rather than undef, leading to it trying to do weird things and breaking horribly: https://fluffy.yelpcorp.com/i/wgTznFPw5PzTDkhgRZJHrrwCL3g8d9SX.html

I'll test this more thoroughly next week but suspect this should be a drop-in replacement and should be fine for both Puppet 4 and 6 clients.

I've tested this works (note: extremely verbose puppet output -- but it worked!) https://fluffy.yelpcorp.com/i/Qt3nLbX1QVDRsG538J3NqmV6LtrbRWkG.html