### PR TITLE
Backport Stdlib::Host from upstream

### DIFF
--- a/types/host.pp
+++ b/types/host.pp
@@ -1,0 +1,2 @@
+# @summary Validate a host (FQDN or IP address)
+type Stdlib::Host = Variant[Stdlib::Fqdn, Stdlib::Compat::Ip_address]

--- a/types/port.pp
+++ b/types/port.pp
@@ -1,0 +1,2 @@
+# @summary Validate a port number
+type Stdlib::Port = Integer[0, 65535]

--- a/types/port/dynamic.pp
+++ b/types/port/dynamic.pp
@@ -1,0 +1,2 @@
+# @summary Validate a dynamic port number
+type Stdlib::Port::Dynamic = Integer[49152, 65535]

--- a/types/port/ephemeral.pp
+++ b/types/port/ephemeral.pp
@@ -1,0 +1,2 @@
+# @summary Validate an ephemeral port number
+type Stdlib::Port::Ephemeral = Stdlib::Port::Dynamic

--- a/types/port/privileged.pp
+++ b/types/port/privileged.pp
@@ -1,0 +1,2 @@
+# @summary Validate a priviliged port number
+type Stdlib::Port::Privileged = Integer[1, 1023]

--- a/types/port/registered.pp
+++ b/types/port/registered.pp
@@ -1,0 +1,2 @@
+# @summary Validate a registered port number
+type Stdlib::Port::Registered = Stdlib::Port::User

--- a/types/port/unprivileged.pp
+++ b/types/port/unprivileged.pp
@@ -1,0 +1,2 @@
+# @summary Validate an unprivileged port number
+type Stdlib::Port::Unprivileged = Integer[1024, 65535]

--- a/types/port/user.pp
+++ b/types/port/user.pp
@@ -1,0 +1,2 @@
+# @summary Validate a port number usable by a user
+type Stdlib::Port::User = Integer[1024, 49151]


### PR DESCRIPTION
Per https://jira.yelpcorp.com/browse/PEAUTO-2573, we presently can't use the Jira module from upstream because Yelp's stdlib doesn't contain this type.
There may be others yet to come but we can import and fix them as we discover them. Once we're on Puppet 6 universally, we can either Just Use That, or at the very least rebase this repo onto the current upstream version with any remaining Yelp changes. (Or, pull Yelp functions out entirely into their own module)

Edit: Adds Stdlib::Port as well.