### PR TITLE
Backport functions from upstream needed for Puppet 8 compatibility

### DIFF
--- a/functions/deferrable_epp.pp
+++ b/functions/deferrable_epp.pp
@@ -1,0 +1,18 @@
+# This function returns either a rendered template or a deferred function to render at runtime.
+# If any of the values in the variables hash are deferred, then the template will be deferred.
+#
+# Note: this function requires all parameters to be explicitly passed in. It cannot expect to
+# use facts, class variables, and other variables in scope. This is because when deferred, we
+# have to explicitly pass the entire scope to the client.
+#
+function stdlib::deferrable_epp(String $template, Hash $variables) >> Variant[String, Sensitive[String], Deferred] {
+  if $variables.stdlib::nested_values.any |$value| { $value.is_a(Deferred) } {
+    Deferred(
+      'inline_epp',
+      [find_template($template).file, $variables],
+    )
+  }
+  else {
+    epp($template, $variables)
+  }
+}

--- a/lib/puppet/functions/fact.rb
+++ b/lib/puppet/functions/fact.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# @summary
+#   Digs into the facts hash using dot-notation
+#
+# Supports the use of dot-notation for referring to structured facts. If a fact requested
+# does not exist, returns Undef.
+#
+# @example Example usage:
+#     fact('osfamily')
+#     fact('os.architecture')
+#
+# @example Array indexing:
+#     fact('mountpoints."/dev".options.1')
+#
+# @example Fact containing a "." in the name:
+#     fact('vmware."VRA.version"')
+#
+Puppet::Functions.create_function(:fact) do
+  # @param fact_name
+  #   The name of the fact to check
+  #
+  # @return
+  #   All information retrieved on the given fact_name
+  dispatch :fact do
+    param 'String', :fact_name
+  end
+
+  def to_dot_syntax(array_path)
+    array_path.map { |string|
+      string.include?('.') ? %("#{string}") : string
+    }.join('.')
+  end
+
+  def fact(fact_name)
+    facts = closure_scope['facts']
+
+    # Transform the dot-notation string into an array of paths to walk. Make
+    # sure to correctly extract double-quoted values containing dots as single
+    # elements in the path.
+    path = fact_name.scan(%r{([^."]+)|(?:")([^"]+)(?:")}).map { |x| x.compact.first }
+
+    walked_path = []
+    path.reduce(facts) do |d, k|
+      return nil if d.nil? || k.nil?
+
+      if d.is_a?(Array)
+        begin
+          result = d[Integer(k)]
+        rescue ArgumentError => e # rubocop:disable Lint/UselessAssignment : Causes errors if assigment is removed.
+          Puppet.warning("fact request for #{fact_name} returning nil: '#{to_dot_syntax(walked_path)}' is an array; cannot index to '#{k}'")
+          result = nil
+        end
+      elsif d.is_a?(Hash)
+        result = d[k]
+      else
+        Puppet.warning("fact request for #{fact_name} returning nil: '#{to_dot_syntax(walked_path)}' is not a collection; cannot walk to '#{k}'")
+        result = nil
+      end
+
+      walked_path << k
+      result
+    end
+  end
+end

--- a/lib/puppet/functions/stdlib/ensure_packages.rb
+++ b/lib/puppet/functions/stdlib/ensure_packages.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# @summary Takes a list of packages and only installs them if they don't already exist.
+#
+# It optionally takes a hash as a second parameter that will be passed as the
+# third argument to the ensure_resource() function.
+Puppet::Functions.create_function(:'stdlib::ensure_packages', Puppet::Functions::InternalFunction) do
+  # @param packages
+  #   The packages to ensure are installed.
+  # @param default_attributes
+  #   Default attributes to be passed to the `ensure_resource()` function
+  # @return [Undef] Returns nothing.
+  dispatch :ensure_packages do
+    scope_param
+    param 'Variant[String[1], Array[String[1]]]', :packages
+    optional_param 'Hash', :default_attributes
+    return_type 'Undef'
+  end
+
+  # @param packages
+  #   The packages to ensure are installed. The keys are packages and values are the attributes specific to that package.
+  # @param default_attributes
+  #   Default attributes. Package specific attributes from the `packages` parameter will take precedence.
+  # @return [Undef] Returns nothing.
+  dispatch :ensure_packages_hash do
+    scope_param
+    param 'Hash[String[1], Any]', :packages
+    optional_param 'Hash', :default_attributes
+    return_type 'Undef'
+  end
+
+  def ensure_packages(scope, packages, default_attributes = {})
+    Array(packages).each do |package_name|
+      defaults = { 'ensure' => 'installed' }.merge(default_attributes)
+
+      # `present` and `installed` are aliases for the `ensure` attribute. If `ensure` is set to either of these values replace
+      # with `installed` by default but `present` if this package is already in the catalog with `ensure => present`
+      defaults['ensure'] = default_ensure(package_name) if ['present', 'installed'].include?(defaults['ensure'])
+
+      scope.call_function('ensure_resource', ['package', package_name, defaults])
+    end
+    nil
+  end
+
+  def ensure_packages_hash(scope, packages, default_attributes = {})
+    packages.each do |package, attributes|
+      ensure_packages(scope, package, default_attributes.merge(attributes))
+    end
+    nil
+  end
+
+  private
+
+  def default_ensure(package_name)
+    if call_function('defined_with_params', "Package[#{package_name}]", { 'ensure' => 'present' })
+      'present'
+    else
+      'installed'
+    end
+  end
+end

--- a/lib/puppet/functions/stdlib/nested_values.rb
+++ b/lib/puppet/functions/stdlib/nested_values.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# @summary Get list of nested values from given hash
+#   This function will return list of nested Hash values and returns list of values in form of Array
+#
+# @example Example Usage:
+#   $hash = {
+#     "key1" => "value1",
+#     "key2" => { "key2.1" => "value2.1"},
+#     "key3" => "value3"
+#   }
+#   $data = $hash.stdlib::nested_values
+#   #Output : ["value1", "value2.1", "value3"]
+Puppet::Functions.create_function(:'stdlib::nested_values') do
+  # @param hash A (nested) hash
+  # @return All the values found in the input hash included those deeply nested.
+  dispatch :nested_values do
+    param 'Hash', :hash
+    return_type 'Array'
+  end
+
+  def nested_values(hash)
+    hash.each_with_object([]) do |(_k, v), values|
+      v.is_a?(Hash) ? values.concat(nested_values(v)) : (values << v)
+    end
+  end
+end


### PR DESCRIPTION
These functions are copied verbatim from upstream to allow for compatibility with Puppet 8.
We should really switch to using the Puppet stdlib, but that's probably a whole project in itself; this at least gets things working.