### PR TITLE
backport of type filesource

### DIFF
--- a/types/filesource.pp
+++ b/types/filesource.pp
@@ -1,0 +1,9 @@
+# @summary Validate the source parameter on file types
+type Stdlib::Filesource = Variant[
+  Stdlib::Absolutepath,
+  Stdlib::HTTPUrl,
+  Pattern[
+    /\Afile:\/\/\/([^\n\/\0]+(\/)?)+\z/,
+    /\Apuppet:\/\/(([\w-]+\.?)+)?\/([^\n\/\0]+(\/)?)+\z/,
+  ],
+]


### PR DESCRIPTION
testing updated chocolatey module. 

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Resource type not found: Stdlib::Filesource (file: /etc/puppet/environments/d__leighton__CORPENG_35281_choco/vendor/modules/chocolatey/manifests/init.pp, line: 81, column: 3) on node winbatch1-usw2b.ad.yelpcorp.com
Error: Not using cached catalog because its environment 'production' does not match 'd__leighton__CORPENG_35281_choco'
Error: Could not retrieve catalog; skipping run
```

copied from https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/types/filesource.pp